### PR TITLE
[BD-6] Changes for python 3.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"
-  - "python -m pip install --no-use-pep517 pyinstaller==3.4"
+  - "python -m pip install --no-use-pep517 pyinstaller==3.6"
 
   # Set up the project in develop mode. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,

--- a/contrib/tx.spec
+++ b/contrib/tx.spec
@@ -26,4 +26,4 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=False,
-          console=True , icon='contrib/tx.ico')
+          console=True , icon='tx.ico')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ urllib3>=1.24.2,<2.0.0
 six<2.0.0
 requests>=2.19.1,<3.0.0
 python-slugify<2.0.0
+gitpython<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urllib3>=1.24.2,<2.0.0
 six<2.0.0
 requests>=2.19.1,<3.0.0
-python-slugify<2.0.0
+python-slugify<5.0.0
 gitpython<4.0.0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -163,7 +163,8 @@ class TestPullCommand(unittest.TestCase):
             branch='a-branch', fetchall=False, fetchsource=False,
             force=False, languages=[], minimum_perc=None, mode=None,
             overwrite=True, pseudo=False, resources=[], skip=False,
-            xliff=False, parallel=False, no_interactive=False
+            xliff=False, parallel=False, no_interactive=False,
+            use_git_timestamps=False
         )
         pr_instance.pull.assert_has_calls([pull_call])
 
@@ -182,7 +183,8 @@ class TestPullCommand(unittest.TestCase):
             branch='somebranch', fetchall=False, fetchsource=False,
             force=False, languages=[], minimum_perc=None, mode=None,
             overwrite=True, pseudo=False, resources=[], skip=False,
-            xliff=False, parallel=False, no_interactive=False
+            xliff=False, parallel=False, no_interactive=False,
+            use_git_timestamps=False
         )
         pr_instance.pull.assert_has_calls([pull_call])
 
@@ -196,7 +198,24 @@ class TestPullCommand(unittest.TestCase):
             fetchall=False, force=False, minimum_perc=None,
             skip=False, no_interactive=True, resources=[], pseudo=False,
             languages=[], fetchsource=False, mode=None, branch=None,
-            xliff=False, parallel=False, overwrite=True
+            xliff=False, parallel=False, overwrite=True,
+            use_git_timestamps=False
+        )
+        self.assertEqual(pr_instance.pull.call_count, 1)
+        pr_instance.pull.assert_has_calls([pull_call])
+
+    @patch('txclib.commands.project')
+    def test_pull_with_git_timestamps(self, project_mock):
+        pr_instance = MagicMock()
+        pr_instance.pull.return_value = True
+        project_mock.Project.return_value = pr_instance
+        cmd_pull(['--use-git-timestamps'], '.')
+        pull_call = call(
+            fetchall=False, force=False, minimum_perc=None,
+            skip=False, no_interactive=False, resources=[], pseudo=False,
+            languages=[], fetchsource=False, mode=None, branch=None,
+            xliff=False, parallel=False, overwrite=True,
+            use_git_timestamps=True
         )
         self.assertEqual(pr_instance.pull.call_count, 1)
         pr_instance.pull.assert_has_calls([pull_call])

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -704,6 +704,27 @@ class TestProjectPull(unittest.TestCase):
                 res = self.p._should_download('pt', self.stats, None, True)
                 self.assertEqual(res, True)
 
+            with patch.object(utils, 'get_git_file_timestamp') as ts_mock:
+                # Note that the test needs an existing file path
+                # The current test (__file__) is the only file
+                # we're sure will exist and won't change
+
+                # Old timestamp (1990)
+                ts_mock.return_value = 640124371
+                res = self.p._should_download(
+                    'pt', self.stats, os.path.abspath(__file__), False,
+                    use_git_timestamps=True
+                )
+                self.assertEqual(res, True)
+
+                # "Recent" timestamp (in the future - 2100)
+                ts_mock.return_value = 4111417171
+                res = self.p._should_download(
+                    'pt', self.stats, os.path.abspath(__file__), False,
+                    use_git_timestamps=True
+                )
+                self.assertEqual(res, False)
+
     def test_get_url_by_pull_mode(self):
         self.assertEqual(
             'pull_sourceastranslation_file',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 import six
 from mock import patch, MagicMock, mock_open
@@ -364,3 +365,22 @@ class ProjectFilesTestCase(unittest.TestCase):
         with six.assertRaisesRegex(self, exceptions.MalformedConfigFile, msg):
             for file, lang in utils.get_project_files(os.getcwd(), expression):
                 pass
+
+class GitUtilsTestCase(unittest.TestCase):
+
+    def test_fetch_timestamp_from_git_tree(self):
+        # A bit meta, lets try to get the timestamp of the
+        # current file
+        epoch_ts = utils.get_git_file_timestamp(
+            os.path.dirname(os.path.abspath(__file__))
+        )
+        self.assertIsNotNone(epoch_ts)
+
+    def test_git_timestamp_is_parsable(self):
+        # A bit meta, lets try to get the timestamp of the
+        # current file
+        epoch_ts = utils.get_git_file_timestamp(
+            os.path.dirname(os.path.abspath(__file__))
+        )
+        parsed_ts = time.mktime(time.gmtime(epoch_ts))
+        self.assertIsNotNone(parsed_ts)

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -414,6 +414,7 @@ def cmd_push(argv, path_to_tx):
     skip = options.skip_errors
     xliff = options.xliff
     parallel = options.parallel
+    use_git_timestamps = options.use_git_timestamps
     prj = project.Project(path_to_tx)
     if not (options.push_source or options.push_translations):
         parser.error("You need to specify at least one of the -s|--source, "
@@ -425,7 +426,8 @@ def cmd_push(argv, path_to_tx):
         skip=skip, source=options.push_source,
         translations=options.push_translations,
         no_interactive=options.no_interactive,
-        xliff=xliff, branch=branch, parallel=parallel
+        xliff=xliff, branch=branch, parallel=parallel,
+        use_git_timestamps=use_git_timestamps,
     )
     logger.info("Done.")
 
@@ -445,6 +447,7 @@ def cmd_pull(argv, path_to_tx):
     parallel = options.parallel
     skip = options.skip_errors
     minimum_perc = options.minimum_perc or None
+    use_git_timestamps = options.use_git_timestamps
 
     _go_to_dir(path_to_tx)
 
@@ -457,6 +460,7 @@ def cmd_pull(argv, path_to_tx):
         force=options.force, skip=skip, minimum_perc=minimum_perc,
         mode=options.mode, pseudo=pseudo, xliff=xliff, branch=branch,
         parallel=parallel, no_interactive=options.no_interactive,
+        use_git_timestamps=use_git_timestamps
     )
     logger.info("Done.")
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -182,6 +182,11 @@ def pull_parser():
     parser.add_argument("--pseudo", action="store_true", dest="pseudo",
                         default=False, help="Apply this option to download "
                         "a pseudo file.")
+    parser.add_argument("--use-git-timestamps", action="store_true",
+                        dest="use_git_timestamps", default=False,
+                        help="Compare local files to their Transifex version "
+                        "by their latest commit timestamps. Use this option, "
+                        "for example, when cloning a Git repository.")
     parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
@@ -244,6 +249,11 @@ def push_parser():
     parser.add_argument("-x", "--xliff", action="store_true", dest="xliff",
                         default=False, help="Apply this option to upload "
                         "file as xliff.")
+    parser.add_argument("--use-git-timestamps", action="store_true",
+                        dest="use_git_timestamps", default=False,
+                        help="Compare local files to their Transifex version "
+                        "by their latest commit timestamps. Use this option, "
+                        "for example, when cloning a Git repository.")
     parser.add_argument(
         "-b", "--branch", action="store", dest="branch",
         default=None, nargs="?", const='-1',

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -3,6 +3,7 @@ import functools
 import os
 import sys
 import re
+import git
 import errno
 import urllib3
 import collections
@@ -733,3 +734,23 @@ def update_progress(done, total):
     # Print a new line when done
     if done == total:
         sys.stdout.write('\n')
+
+
+def get_git_file_timestamp(file_path):
+    """
+    Return the timestamp (epoch) for the latest commit of a file
+    """
+    try:
+        repo = git.Repo()
+        commits_touching_path = list(
+            repo.iter_commits(paths=file_path, max_count=1)
+        )
+        if commits_touching_path:
+            latest_commit = commits_touching_path[0]
+            latest_commit_ts = latest_commit.committed_date
+            return latest_commit_ts
+        else:
+            return None
+    except git.InvalidGitRepositoryError:
+        # Current path is not a git repo.
+        return None


### PR DESCRIPTION
This adds the changes from https://github.com/transifex/transifex-client/pull/293 in order to use this in edx-platform provisionally until that gets merged

__Note__: There are two commits because upstream has one commit more in the main branch

The actual problem that we have in edx-platform is that the last version of transifex-client has as constraint python-slugify<2.0.0 which is not compatible with the current requierements of edx-platform on the other hand, the current version used in edx-platform is not compatible with python3.8

You can see that in: https://github.com/edx/edx-platform/blob/aa3501c63a8f801251e6e2b6f429f17b8997e0df/requirements/constraints.txt#L100
## Reviewers
 - [x] @awais786 
- [ ] @jmbowman 