### PR TITLE
[BD-6] Loosen up python-slugify dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"
-  - "python -m pip install --no-use-pep517 pyinstaller==3.4"
+  - "python -m pip install --no-use-pep517 pyinstaller==3.6"
 
   # Set up the project in develop mode. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,

--- a/contrib/tx.spec
+++ b/contrib/tx.spec
@@ -26,4 +26,4 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=False,
-          console=True , icon='contrib/tx.ico')
+          console=True , icon='tx.ico')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urllib3>=1.24.2,<2.0.0
 six<2.0.0
 requests>=2.19.1,<3.0.0
-python-slugify<2.0.0
+python-slugify<5.0.0
 gitpython<4.0.0


### PR DESCRIPTION
The same as https://github.com/edx/transifex-client/pull/1

This adds the changes from https://github.com/transifex/transifex-client/pull/293 in order to use this in edx-platform provisionally until that gets merged

__Note__: There are two commits because upstream has one commit more in the main branch

The actual problem that we have in edx-platform is that the last version of transifex-client has as constraint python-slugify<2.0.0 which is not compatible with the current requierements of edx-platform on the other hand, the current version used in edx-platform is not compatible with python3.8

You can see that in: https://github.com/edx/edx-platform/blob/aa3501c63a8f801251e6e2b6f429f17b8997e0df/requirements/constraints.txt#L100
## Reviewers
 - [x] @awais786 
- [x] @jmbowman 